### PR TITLE
Fix global leak typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ Caseless.prototype.has = function (name) {
 }
 Caseless.prototype.get = function (name) {
   name = name.toLowerCase()
-  var result, key
+  var result, _key
   var headers = this.dict
   Object.keys(headers).forEach(function (key) {
     _key = key.toLowerCase()


### PR DESCRIPTION
@mikeal I believe you meant to have an underscore in front of "key" on line 29.  If it is not there, the _key variable used on line 32 leaks into the global namespace.  Please review and merge.
