### PR TITLE
Protect against undefined values.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = function (dict) {return new Caseless(dict)}
 module.exports.httpify = function (resp, headers) {
   var c = new Caseless(headers)
   resp.setHeader = function (key, value, clobber) {
+    if (typeof value === 'undefined') return
     return c.set(key, value, clobber)
   }
   resp.hasHeader = function (key) {


### PR DESCRIPTION
0.12.x and io.js both took a breaking change in `.setHeader()` that now breaks on undefined values. This is a nice way to protect against it.