### PR TITLE
Make caseless.del() work ok on duplicates, update readme and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Caseless -- wrap an object to set and get property with caseless semantics but also preserve caseing.
 
-This library is incredibly useful when working with HTTP headers. It allows you to get/set/check for headers in a caseless manner while also preserving the caseing of headers the first time they are set.
+This library is incredibly useful when working with HTTP headers. It allows you to get/set/check/delete headers in a caseless manner while also preserving the headers' case when they are first set.
 
 ## Usage
 
@@ -42,4 +42,24 @@ c.set('a-Header', 'fdas')
 c.swap('a-HEADER')
 c.has('a-header') === 'a-HEADER'
 headers === {'a-HEADER': 'fdas'}
+```
+
+## del(key)
+
+Deletes a key and, if there's many instances of the key with multiple cases, all of them.
+
+```javascript
+
+var headers = {
+  'a-Header': true,
+  'content-length': 312,
+  'Content-Length': 312
+}
+var c = caseless(headers);
+
+c.del('Content-length');
+headers === {
+  'a-Header': true
+};
+
 ```

--- a/index.js
+++ b/index.js
@@ -42,8 +42,17 @@ Caseless.prototype.swap = function (name) {
   delete this.dict[has]
 }
 Caseless.prototype.del = function (name) {
-  var has = this.has(name)
-  return delete this.dict[has || name]
+  name = String(name).toLowerCase()
+  var deleted = false
+  var changed = 0
+  var dict = this.dict
+  Object.keys(this.dict).forEach(function(key) {
+    if (name === String(key).toLowerCase()) {
+      deleted = delete dict[key]
+      changed += 1
+    }
+  })
+  return changed === 0 ? true : deleted
 }
 
 module.exports = function (dict) {return new Caseless(dict)}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caseless",
   "version": "0.12.1",
-  "description": "Caseless object set/get/has, very useful when working with HTTP headers.",
+  "description": "Caseless object set/get/has/del, very useful when working with HTTP headers.",
   "main": "index.js",
   "scripts": {
     "test": "node test.js"

--- a/test.js
+++ b/test.js
@@ -65,3 +65,20 @@ tape('swap', function (t) {
     c.swap('content-type')
   })
 })
+
+tape('del', function (t) {
+  var headers = {
+    'X-Random-Header': 'X',
+    'Content-Type': 'A',
+    'content-type': 'B'
+  }
+  var c = caseless(headers)
+  t.plan(4)
+  // Both headers should still be there
+  t.ok(c.has('X-Random-Header'))
+  t.ok(c.has('Content-Type'))
+  // Del should delete them all
+  c.del('Content-type')
+  t.ok(!c.has('Content-type'))
+  t.deepEqual(headers, {'X-Random-Header': 'X'})
+});


### PR DESCRIPTION
When the dictionary was set with multiple duplicates, `del()` misbehaves as it will keep all the other duplicates unless you call `del()` as many times as there are duplicates.

Tests are written, there are no breaking changes.